### PR TITLE
feat: Add suffix_as_filetype support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ use {
  disable_autocmd = false, -- Disable the autocmd that creates the template.  You can use manually by calling :InsertTemplateFile,
  disable_filetype = {}, -- Disable templates for a filetype (disable only default templates.  User templates will work).
  disable_specific = {}, -- Disable specific regexp for the default templates.  Example: { ruby = { ".*" } }.  To see the regexps, just look into lua/templates/{filetype}.lua for the regexp being used.
+ suffix_as_filetype = false, -- use suffix of filename rather than vim.bo.filetype as filetype
 }
 ```
 # Creating new templates
@@ -143,3 +144,4 @@ If for some reason, the template ignores your empty lines, just add \n on the pr
 This plugin is in its early stages, and we welcome your help! If you use some framework that is not in the defaults, please open a PR to contribute to the project. Any help is welcome.
 
 If you use some framework that is not on the defaults, please, open an PR to help the project! Any help is welcome.
+

--- a/lua/new-file-template/init.lua
+++ b/lua/new-file-template/init.lua
@@ -11,6 +11,7 @@ function M.setup(opts)
 		disable_autocmd = opts.disable_autocmd or {},
 		disable_specific = opts.disable_specific or {},
 		disable_filetype = opts.disable_filetype or {},
+        suffix_as_filetype = opts.suffix_as_filetype or false,
 	})
 
 	if not opts.disable_autocmd then
@@ -55,6 +56,13 @@ end
 function M.open_user_config(filetype)
 	if not filetype or filetype == "" then
 		filetype = vim.bo.filetype
+
+        if state.getState().suffix_as_filetype then
+            local ft = vim.api.nvim_buf_get_name(0):match("^.+%.(.+)$")
+            if ft ~= nil then
+                filetype = ft
+            end
+        end
 	end
 
 	local config_path = vim.fn.stdpath("config")
@@ -112,6 +120,13 @@ function M.insert_template()
 	local path = vim.fn.fnamemodify(new_file_relative_path, ":h")
 	local new_file_filetype = vim.bo.filetype
 
+    if state.getState().suffix_as_filetype then
+        local ft = filename:match("^.+%.(.+)$")
+        if ft ~= nil then
+            new_file_filetype = ft
+        end
+    end
+
 	local opts_for_template = {
 		full_path = new_file_relative_path,
 		relative_path = path,
@@ -147,3 +162,4 @@ function M.insert_template()
 end
 
 return M
+


### PR DESCRIPTION
Get filetype by `vim.bo.filetype` sometime might got unexpected result，for example:

* foo.cu -> `cuda`, use template `lua/templates/cuda.lua` for `*.cu` file
* foo.hpp -> `cpp`, use template `lua/templates/cpp.lua` for `*.hpp` file
* foo.h -> `cpp`, use template `lua/templates/cpp.lua` for `*.h` file
* foo.user_define_type -> `''`, seems to be unsupported ?
* foo.md -> `markdown`, use template `lua/templates/markdown.lua` for  `*.md` file
* foo.ts -> `typescript`, use template `lua/templates/typescript.lua` for `*.ts` file
* foo.tsx -> `typescriptreact`, , use template `lua/templates/typescriptreact.lua` for `*.tsx` file

This PR add suffix_as_filetype support, if `suffix_as_filetype = true` then 

* foo.cu -> `cu`, use template `lua/templates/cu.lua` for `*.cu` file
* foo.hpp -> `hpp`, use template `lua/templates/hpp.lua` for `*.hpp` file
* foo.h -> `h`, use template `lua/templates/h.lua` for  `*.h` file
* foo.user_define_type -> `user_define_type`, use template `lua/templates/user_define_type.lua` for `*.user_define_type` file
* foo.md -> `md`, use template `lua/templates/md.lua` for `*.md` file
* foo.ts -> `ts`, use template `lua/templates/ts.lua` for  `*.ts` file
* foo.tsx -> `tsx`, , use template `lua/templates/tsx.lua` for  `*.tsx` file

