### PR TITLE
Fixed templates not supporting escaping newline characters

### DIFF
--- a/lua/new-file-template/init.lua
+++ b/lua/new-file-template/init.lua
@@ -78,8 +78,9 @@ end
 
 function M.insert_text(template)
 	local current_buffer = vim.api.nvim_get_current_buf()
-	template = template:gsub("(?<!\\)\\n", "\n")
-	template = template:gsub("\\\\n", "\\n")
+	template = template:gsub("\\\\n", "ESCAPED_NEWLINE_CHAR") -- Replace escaped newline chars with a place holder
+	template = template:gsub("\\n", "\n") -- Replace real newline chars with the actual escape code
+	template = template:gsub("ESCAPED_NEWLINE_CHAR", "\\n") -- Replace place holders with not-escaped newline chars
 
 	local lines = vim.split(template, "\n")
 

--- a/lua/new-file-template/init.lua
+++ b/lua/new-file-template/init.lua
@@ -78,7 +78,8 @@ end
 
 function M.insert_text(template)
 	local current_buffer = vim.api.nvim_get_current_buf()
-	template = template:gsub("\\n", "\n")
+	template = template:gsub("(?<!\\)\\n", "\n")
+	template = template:gsub("\\\\n", "\\n")
 
 	local lines = vim.split(template, "\n")
 


### PR DESCRIPTION
Added support for adding `\\n` characters into templates to result the literal string `\n` to be present in the applied template. Previously, this would have resulted in a single `\` followed by a new line.

### Motivation
The **LaTeX** language calls commands by starting them with a backslash (`\`), and any commands that started with `\n` got chopped up.
For example let use `\newpage`. Putting `\newpage` into the template resulted in 
```

ewpage
```
and putting `\\newpage` resulted in 
```
\
ewpage
```
Not ideal. 

This change allows putting `\\newpage` (for example) into the template inside the lua file template and it will be replaced with 
```
\newline
```
in the resulting file after the template has been applied, as expected.

This change still supports regular `\n`s to intentionally add newlines to your template but now allows them to be escaped.